### PR TITLE
allow missing samples

### DIFF
--- a/bin/reportGeneration/LibraryReport.py
+++ b/bin/reportGeneration/LibraryReport.py
@@ -151,9 +151,12 @@ class LibraryReport(AbstractReport):
         self.sampleQCDf['rankOrder'] = self.sampleQCDf.cellNum
         plottingDf = self.sampleQCDf[self.sampleQCDf['rankOrder'].isin(indiciesToInclude)]
         fig = px.line(plottingDf, x=plottingDf.cellNum, y='UniqueReads', color='sample', log_x=True, log_y=True, template=constants.DEFAULT_FIGURE_STYLE, labels={"cellNum": "Cell Barcodes"}, title="Per Sample: Reads Per Cell Barcode")
-        colorsBeingUsed = px.colors.qualitative.D3
+        colorsBeingUsed = px.colors.qualitative.Dark24 + px.colors.qualitative.Light24
         # Adding vertical lines at cells above threshold for each sample (in same color)
         for i, (_, cellCount) in enumerate(sorted(cellsAboveDict.items())):
+            # cycle colors
+            while i >= len(colorsBeingUsed):
+                i -= len(colorsBeingUsed)
             fig.add_vline(x=cellCount, line_dash="dash", line_color=colorsBeingUsed[i])
         return dp.Plot(fig)
 
@@ -170,7 +173,8 @@ class LibraryReport(AbstractReport):
         (countsPerSampleDf, lvl1BcCountsPerSampleDf) = self.buildDfFromDemuxSampleMetrics()
         lvl1BcCountsPerSampleDf.sort_values(by=[self.barcodesToPlot[1],'Sample'], inplace=True)
         countsPerSampleDf.sort_values(by=['Sample'], inplace=True)
-        colorMapToUse = LibraryReport.matchColorsToNames(px.colors.qualitative.D3, list(countsPerSampleDf['Sample'].unique()))
+        colorsBeingUsed = px.colors.qualitative.Dark24 + px.colors.qualitative.Light24
+        colorMapToUse = LibraryReport.matchColorsToNames(colorsBeingUsed, list(countsPerSampleDf['Sample'].unique()))
         readsPerSample = px.bar(countsPerSampleDf, x='TotalReads', y='Sample', color='Sample',height=500, color_discrete_map=colorMapToUse,template=constants.DEFAULT_FIGURE_STYLE, title="Reads per sample")
         lvl1BcCountsPerSampleDf.sort_values(by=['Sample'], inplace=True)
         readsPerWellBySample = px.bar(lvl1BcCountsPerSampleDf, x='ReadCount', y=self.barcodesToPlot[1], color='Sample',height=500,template=constants.DEFAULT_FIGURE_STYLE, color_discrete_map=colorMapToUse, labels={self.barcodesToPlot[1]: f'{self.barcodesToPlot[1]} Barcode ', 'ReadCount':'Total Reads'}, title=f"Reads count by {self.barcodesToPlot[1]} Barcode")
@@ -181,7 +185,7 @@ class LibraryReport(AbstractReport):
                 title='Reads'
         )    
 
-    def matchColorsToNames(colorPalette, names) -> Dict[str,str]:
+    def matchColorsToNames(colorsBeingUsed, names) -> Dict[str,str]:
         colorMap = {"Unknown": 'rgb(179, 188, 201)'}
         if ("Unknown" in names):
             names.remove('Unknown')
@@ -189,8 +193,10 @@ class LibraryReport(AbstractReport):
         Associated colors with categorical values @names
         for consistency between plots 
         '''
-        colorsBeingUsed = px.colors.qualitative.D3
         for i,name in enumerate(sorted(names)):
+            # cycle colors
+            while i >= len(colorsBeingUsed):
+                i -= len(colorsBeingUsed)
             colorMap[name] = colorsBeingUsed[i]
         return colorMap
 

--- a/bin/reportGeneration/LibraryReport.py
+++ b/bin/reportGeneration/LibraryReport.py
@@ -34,13 +34,20 @@ class LibraryReport(AbstractReport):
         for sample in self.sampleNames:
             filePaths = {}
             if str(self.resultsDir) == '.':
-                filePaths['filterDfPath'] = self.resultsDir / f'{sample}_QC.tsv'
-                filePaths['threshJsonPath'] = self.resultsDir / f'{sample}_thresholds.json'
+                prefix = self.resultsDir
             else:
-                QCPrefix = self.resultsDir / 'QC' / sample / self.qcSubdirectory
-                filePaths['filterDfPath'] = QCPrefix / f'{sample}_QC.tsv'
-                filePaths['threshJsonPath'] = QCPrefix / f'{sample}_thresholds.json'
-            sampleToFilePaths[sample] = filePaths
+                prefix = self.resultsDir / 'QC' / sample / self.qcSubdirectory
+            filePaths['filterDfPath'] = prefix / f'{sample}_QC.tsv'
+            filePaths['threshJsonPath'] = prefix / f'{sample}_thresholds.json'
+            # skip
+            if filePaths['filterDfPath'].is_file() and filePaths['threshJsonPath'].is_file():
+                sampleToFilePaths[sample] = filePaths
+        if len(sampleToFilePaths) == 0:
+            if str(self.resultsDir) == '.':
+                prefix = self.resultsDir
+            else:
+                prefix = self.resultsDir / 'QC'
+            raise FileNotFoundError(f"Zero of {len(self.sampleNames)} QC files found in {prefix}.")
         return sampleToFilePaths
 
     def validateInput(self):

--- a/envs/scaleAtac.conda.yml
+++ b/envs/scaleAtac.conda.yml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - numpy
-  - pandas
-  - pybedtools
-  - samtools
-  - bedtools
-  - tabix
-  - bowtie2
-  - cutadapt
-  - fastqc
-  - multiqc
-  - macs3
+  - numpy=2.2.5
+  - pandas=2.2
+  - pybedtools=0.12
+  - samtools=1.21
+  - bedtools=2.31
+  - tabix=1.11  # may need to upgrade to htslib in the future. See https://github.com/samtools/tabix
+  - bowtie2=2.5
+  - cutadapt=5.0
+  - fastqc=0.12
+  - multiqc=1.28
+  - macs3=3.0.3


### PR DESCRIPTION
use case: duplicate library indexes, used between two different plates, in the same wells. 
In this case, the reads are attributed to one of the two subsamples.